### PR TITLE
Update the module to use the RSC provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module "rubrik_azure_cloud_cluster_elastic_storage" {
   admin_email           = "build@rubrik.com"
   admin_password        = "RubrikGoForward"
   dns_search_domain     = ["rubrikdemo.com"]
-  dns_name_servers      = ["192.168.100.5"."192.168.100.6"]
+  dns_name_servers      = ["192.168.100.5","192.168.100.6"]
   ntp_server1_name      = "8.8.8.8"
   ntp_server2_name      = "8.8.4.4"
 }

--- a/main.tf
+++ b/main.tf
@@ -264,24 +264,20 @@ resource "time_sleep" "wait_for_nodes_to_boot" {
   depends_on = [azurerm_virtual_machine_data_disk_attachment.cces_cache_disk]
 }
 
-resource "rubrik_bootstrap_cces_azure" "bootstrap_rubrik_cces_aws" {
-  cluster_name            = "${var.cluster_name}"
-  admin_email             = "${var.admin_email}"
-  admin_password          = "${var.admin_password}"
-  management_gateway      = "${cidrhost(data.azurerm_subnet.cces_subnet.address_prefixes.0, 1)}"
-  management_subnet_mask  = "${cidrnetmask(data.azurerm_subnet.cces_subnet.address_prefixes.0)}"
-  dns_search_domain       = "${var.dns_search_domain}"
-  dns_name_servers        = "${var.dns_name_servers}"
-  ntp_server1_name        = "${var.ntp_server1_name}"
-  ntp_server2_name        = "${var.ntp_server2_name}"
-
-  enable_encryption       = false
+resource "polaris_cdm_bootstrap_cces_azure" "bootstrap_cces_azure" {
+  cluster_name            = var.cluster_name
+  cluster_nodes           = zipmap(local.cluster_node_names, local.cluster_node_ips)
+  admin_email             = var.admin_email
+  admin_password          = var.admin_password
+  management_gateway      = cidrhost(data.azurerm_subnet.cces_subnet.address_prefixes.0, 1)
+  management_subnet_mask  = cidrnetmask(data.azurerm_subnet.cces_subnet.address_prefixes.0)
+  dns_search_domain       = var.dns_search_domain
+  dns_name_servers        = var.dns_name_servers
+  ntp_server1_name        = var.ntp_server1_name
+  ntp_server2_name        = var.ntp_server2_name
   connection_string       = azurerm_storage_account.cc_storage_account.primary_connection_string
   container_name          = var.cluster_name
   enable_immutability     = var.enableImmutability
-
-  node_config             = "${zipmap(local.cluster_node_names, local.cluster_node_ips)}"
-  timeout                 = "${var.timeout}"
-
+  timeout                 = var.timeout
   depends_on              = [time_sleep.wait_for_nodes_to_boot]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,8 +7,9 @@ terraform {
     azapi = {
       source = "Azure/azapi"
     }
-    rubrik = {
-      source   = "rubrikinc/rubrik/rubrik"
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "=0.8.0-beta.4"
     }
   }
 }
@@ -25,8 +26,4 @@ provider "azurerm" {
 
 provider "azapi" {}
 
-provider "rubrik" {
-  node_ip  = local.cluster_node_ips.0
-  username = ""
-  password = ""
-}
+provider "polaris" {}

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,6 @@ variable "ntp_server2_key_type" {
 }
 variable "timeout" {
   description = "The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error."
-  type        = number
-  default     = 60
+  type        = string
+  default     = "4m"
 }


### PR DESCRIPTION
# Description

Update the module to use the RSC Terraform provider instead of the CDM Terraform provider.

## Motivation and Context

The RSC Terraform provider is published to the Terraform Registry making it much easier to use than the CDM Terraform provider.

## How Has This Been Tested?

* Deployed an Azure CCES cluster and verified that it was up and running.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
