### PR TITLE
Add support for CDM versions using split disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ westus2     rubrik-cdm-90
 Tke SKUs in the output will represent the major and minor version numbers of the various Rubrik CCES releases. For example `rubrik-cdm-90` represents Rubrik CDM v9.0.x. The specific
 maintenance release will be selected later on. select the SKU name for the version of CCES that you plan to use.
 
-Next the plan name for the SKU that has been selected must obtained. Generally with CCES the plan name and the SKU name are the same, however, it is best to check in case they do differ.
+Next the plan name for the SKU that has been selected must be obtained. Generally with CCES the plan name and the SKU name are the same, however, it is best to check in case they do differ.
 To do this run the command:
 
 `az vm image show --location <location> --urn rubrik-inc:rubrik-data-protection:<SKU>:latest --query plan.name --output tsv`
@@ -161,7 +161,6 @@ Example:
 
 ```
 -> az vm image show --location westus2 --urn rubrik-inc:rubrik-data-protection:rubrik-cdm-90:latest --query plan.name --output tsv    
-rubrik-cdm-90
 ```
 
 Next the Azure Marketplace Agreement must be accepted. To do this run the command:

--- a/main.tf
+++ b/main.tf
@@ -155,11 +155,11 @@ resource "azurerm_ssh_public_key" "cc_public_ssh_key" {
 ######################k#####################
 
 resource "azurerm_network_interface" "cces_nic" {
-  for_each                      = toset(local.cluster_node_names)
-  name                          = "${each.value}-nic"
-  resource_group_name           = azurerm_resource_group.cc_rg.name
-  location                      = azurerm_resource_group.cc_rg.location
-  enable_accelerated_networking = true
+  for_each                       = toset(local.cluster_node_names)
+  name                           = "${each.value}-nic"
+  resource_group_name            = azurerm_resource_group.cc_rg.name
+  location                       = azurerm_resource_group.cc_rg.location
+  accelerated_networking_enabled = true
 
   ip_configuration {
   name                          = each.value
@@ -172,7 +172,7 @@ resource "azurerm_network_interface" "cces_nic" {
 }
 
 resource "azurerm_management_lock" "cces_nic" {
-  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : null
+  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : []
   name       = "${each.value}-nic"
   scope      = azurerm_network_interface.cces_nic[each.value].id
   lock_level = "CanNotDelete"
@@ -218,14 +218,14 @@ resource "azurerm_linux_virtual_machine" "cces_node" {
 }
 
 resource "azurerm_management_lock" "cces_node" {
-  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : null
+  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : []
   name        = "${each.value}-vm"
   scope      = azurerm_linux_virtual_machine.cces_node[each.value].id
   lock_level = "CanNotDelete"
   notes      = "Locked because this is a critical resource."
 }
 
-resource "azurerm_managed_disk" "cces_cache_disk" {
+resource "azurerm_managed_disk" "cces_data_disk" {
   for_each             = toset(local.cluster_node_names)
   name                 = "${each.value}-disk"
   location             = azurerm_resource_group.cc_rg.location
@@ -233,24 +233,79 @@ resource "azurerm_managed_disk" "cces_cache_disk" {
   storage_account_type = "Premium_LRS"
   create_option        = "Empty"
   disk_size_gb         = "512"
+  tags                 = var.azure_tags
+}
 
-  tags = var.azure_tags
+resource "azurerm_management_lock" "cces_data_disk" {
+  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : []
+  name       = "${each.value}-disk"
+  scope      = azurerm_managed_disk.cces_data_disk[each.value].id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a critical resource."
+}
 
+resource "azurerm_virtual_machine_data_disk_attachment" "cces_data_disk" {
+  for_each           = toset(local.cluster_node_names)
+  managed_disk_id    = azurerm_managed_disk.cces_data_disk[each.value].id
+  virtual_machine_id = azurerm_linux_virtual_machine.cces_node[each.value].id
+  lun                = "0"
+  caching            = "ReadWrite"
+}
+
+# Create 2 additional disks, one for metadata and for cache, per cluster node
+# for CDM version 9.2.2 and later.
+
+resource "azurerm_managed_disk" "cces_metadata_disk" {
+  for_each             = local.split_disk ? toset(local.cluster_node_names) : []
+  name                 = "${each.value}-metadata-disk"
+  location             = azurerm_resource_group.cc_rg.location
+  resource_group_name  = azurerm_resource_group.cc_rg.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "132"
+  tags                 = var.azure_tags
+}
+
+resource "azurerm_management_lock" "cces_metadata_disk" {
+  for_each   = local.split_disk && var.azure_resource_lock ? toset(local.cluster_node_names) : []
+  name       = "${each.value}-metadata-disk"
+  scope      = azurerm_managed_disk.cces_metadata_disk[each.value].id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a critical resource."
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "cces_metadata_disk" {
+  for_each           = local.split_disk ? toset(local.cluster_node_names) : []
+  managed_disk_id    = azurerm_managed_disk.cces_metadata_disk[each.value].id
+  virtual_machine_id = azurerm_linux_virtual_machine.cces_node[each.value].id
+  lun                = "1"
+  caching            = "ReadWrite"
+}
+
+resource "azurerm_managed_disk" "cces_cache_disk" {
+  for_each             = local.split_disk ? toset(local.cluster_node_names) : []
+  name                 = "${each.value}-cache-disk"
+  location             = azurerm_resource_group.cc_rg.location
+  resource_group_name  = azurerm_resource_group.cc_rg.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "206"
+  tags                 = var.azure_tags
 }
 
 resource "azurerm_management_lock" "cces_cache_disk" {
-  for_each   = var.azure_resource_lock == true ? toset(local.cluster_node_names) : null
-  name       = "${each.value}-disk"
+  for_each   = local.split_disk && var.azure_resource_lock ? toset(local.cluster_node_names) : []
+  name       = "${each.value}-cache-disk"
   scope      = azurerm_managed_disk.cces_cache_disk[each.value].id
   lock_level = "CanNotDelete"
   notes      = "Locked because this is a critical resource."
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "cces_cache_disk" {
-  for_each           = toset(local.cluster_node_names)
+  for_each           = local.split_disk ? toset(local.cluster_node_names) : []
   managed_disk_id    = azurerm_managed_disk.cces_cache_disk[each.value].id
   virtual_machine_id = azurerm_linux_virtual_machine.cces_node[each.value].id
-  lun                = "0"
+  lun                = "2"
   caching            = "ReadWrite"
 }
 
@@ -261,7 +316,11 @@ resource "azurerm_virtual_machine_data_disk_attachment" "cces_cache_disk" {
 resource "time_sleep" "wait_for_nodes_to_boot" {
   create_duration = "300s"
 
-  depends_on = [azurerm_virtual_machine_data_disk_attachment.cces_cache_disk]
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.cces_data_disk,
+    azurerm_virtual_machine_data_disk_attachment.cces_metadata_disk,
+    azurerm_virtual_machine_data_disk_attachment.cces_cache_disk,
+  ]
 }
 
 resource "polaris_cdm_bootstrap_cces_azure" "bootstrap_cces_azure" {

--- a/providers.tf
+++ b/providers.tf
@@ -2,10 +2,12 @@ terraform {
   required_version = ">= 1.2.0"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
+      version = "~>4.14.0"
     }
     azapi = {
-      source = "Azure/azapi"
+      source  = "Azure/azapi"
+      version = "~>1.15.0"
     }
     polaris = {
       source  = "rubrikinc/polaris"

--- a/split_disk.tf
+++ b/split_disk.tf
@@ -1,0 +1,16 @@
+locals {
+  # Regular expressions parsing the CCES SKU and version. Note, version can be
+  # either a version number or latest.
+  sku_regex     = "^rubrik-cdm-(\\d+)$"
+  version_regex = "^(\\d+).(\\d+).(\\d+)$|^(latest)$"
+
+  # Extract the major, minor and maintenance version numbers from the CCES SKU
+  # and version strings.
+  major_minor_version = parseint(regex(local.sku_regex, var.azure_cces_sku)[0], 10)
+  maint_patch_build   = regex(local.version_regex, var.azure_cces_version)
+  maint_version       = local.maint_patch_build[0] == null ? 0 : parseint(local.maint_patch_build[0], 10)
+
+  # Determine if the split disk feature is enabled based on the major, minor and
+  # maintenance version numbers.
+  split_disk = local.major_minor_version > 92 || (local.major_minor_version == 92 && (var.azure_cces_version == "latest" || local.maint_version >= 2)) ? true : false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -31,12 +31,22 @@ variable "azure_cces_plan_name" {
 variable "azure_cces_sku" {
   description = "The SKU for the Azure Marketplace Image of CCES to deploy. See the README.MD file of this module for information on finding the SKU."
   type        = string
+
+  validation {
+    condition     = can(regex(local.sku_regex, var.azure_cces_sku))
+    error_message = "The SKU must be in the format 'rubrik-cdm-<version>'. For example, 'rubrik-cdm-92'."
+  }
 }
 
 variable "azure_cces_version" {
   description = "The version of CCES to deploy. Use 'latest' to deploy the latest available version. Note: This only applies to the version within a SKU (major/minor version)."
   type        = string
-  default     = "latest"  
+  default     = "latest"
+
+  validation {
+    condition     = can(regex(local.version_regex, var.azure_cces_version))
+    error_message = "The version must be in the format '<minor>.<maintenance>.<build>' for CDM version 8.1 and later or '<major>.<minor>.<maintenance>' for CDM 8.0 and earlier. For example, '2.1.29213'."
+  }
 }
 
 variable "azure_cces_vm_size" {


### PR DESCRIPTION
# Description

CDM version 9.2.2 and later uses a split disk (metadata and cache), update the Terraform configuration to create the additional disks when needed. There are no additional input required by the user.

## How Has This Been Tested?

Tested by deploying an older and a newer CCES cluster to Azure and verifying that the all required disks were created.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
