### PR TITLE
Fix Azure_subscription_ID variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,18 @@ There are a few services you'll need in order to get this project off the ground
 ### Usage
 
 ```hcl
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+  subscription_id = "12345678-1234-1234-1234-123456789012"
+}
 module "rubrik_azure_cloud_cluster_elastic_storage" {
   source  = "rubrikinc/rubrik-cloud-cluster-elastic-storage/azure"
+  version = "1.0.1"
 
   azure_location        = "West US2"
   azure_resource_group  = "Rubrik-CCES" 
@@ -50,7 +60,7 @@ module "rubrik_azure_cloud_cluster_elastic_storage" {
 ## Changelog
 
 ### v1.0.1
-- Deprecate `azure_subscription_id` variable in favor of provider configuration
+- Deprecate `azure_subscription_id` variable in favor of provider configuration provided by the root module.
 
 ### v1.0.0
 - Remove hard-coded provider setup
@@ -76,11 +86,31 @@ module "rubrik_azure_cloud_cluster_elastic_storage" {
 
 ### v1.0.0 to v1.0.1
 
-1. Update the `source` line in the `module` block to `source  = "rubrikinc/rubrik-cloud-cluster-elastic-storage/azure"`
-2. Update the `version` line in the `module` block to `version = "1.0.1"`
-3. Remove the `azure_subscription_id` variable from the `module` block if present.
-4. Run `terraform init --upgrade` to update the module
-5. Run `terraform plan` to verify the upgrade
+1. Update the `version` line in the `module` block to `version = "1.0.1"`
+3. Run `terraform init --upgrade` to update the module
+4. Run `terraform plan` to verify no changes in the diff:
+```log
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+╷
+│ Warning: Check block assertion failed
+│ 
+│   on ../../terraform-azure-rubrik-cloud-cluster-elastic-storage/variables.tf line 200, in check "depercations":
+│  200:     condition     = var.azure_subscription_id == null
+│     ├────────────────
+│     │ var.azure_subscription_id is "12345678-1234-1234-1234-123456789012"
+│ 
+│ The 'azure_subscription_id' variable is deprecated and should not be used as it will be removed in a future release. Configure the subscription ID in the azurerm provider configuration instead.
+╵
+```
+5. You are safe to remove the `azure_subscription_id` variable from the `module` configuration.
+4. Run `terraform plan` to verify no changes in the diff:
+```log
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+```
 
 ### v0.2.0 to v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ module "rubrik_azure_cloud_cluster_elastic_storage" {
 
 ## Changelog
 
+### v1.0.1
+- Deprecate `azure_subscription_id` variable in favor of provider configuration
+
 ### v1.0.0
 - Remove hard-coded provider setup
 - Add TF-Docs
@@ -70,6 +73,14 @@ module "rubrik_azure_cloud_cluster_elastic_storage" {
 - Core Azure resource provisioning
 
 ## Upgrading
+
+### v1.0.0 to v1.0.1
+
+1. Update the `source` line in the `module` block to `source  = "rubrikinc/rubrik-cloud-cluster-elastic-storage/azure"`
+2. Update the `version` line in the `module` block to `version = "1.0.1"`
+3. Remove the `azure_subscription_id` variable from the `module` block if present.
+4. Run `terraform init --upgrade` to update the module
+5. Run `terraform plan` to verify the upgrade
 
 ### v0.2.0 to v1.0.0
 
@@ -355,7 +366,7 @@ Once the Cloud Cluster is no longer required, it can be destroyed using the `ter
 | <a name="input_azure_sa_name"></a> [azure\_sa\_name](#input\_azure\_sa\_name) | The name of the Azure Storage Account to create for Rubrik Cloud Cluster resources. | `string` | n/a | yes |
 | <a name="input_azure_sa_replication_type"></a> [azure\_sa\_replication\_type](#input\_azure\_sa\_replication\_type) | The type of replication to use with the the Azure Storage Account for Rubrik Cloud Cluster. | `string` | `"LRS"` | no |
 | <a name="input_azure_subnet_name"></a> [azure\_subnet\_name](#input\_azure\_subnet\_name) | Name of the Azure subnet to deploy Rubrik Cloud Cluster into. This subnet must be in the VNet that is defined in the 'azure\_vnet\_name' variable. | `string` | n/a | yes |
-| <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources. | `string` | n/a | yes |
+| <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources. DEPRECATED: This variable is no longer required as the subscription ID is now determined by the provider configuration. | `string` | `null` | no |
 | <a name="input_azure_tags"></a> [azure\_tags](#input\_azure\_tags) | Tags to add to the Azure resources that this Terraform script creates, including the Rubrik cluster nodes. | `map(string)` | `{}` | no |
 | <a name="input_azure_vnet_name"></a> [azure\_vnet\_name](#input\_azure\_vnet\_name) | Name of the Azure Virtual Network (VNet) to deploy Rubrik Cloud Cluster ES into. | `string` | n/a | yes |
 | <a name="input_azure_vnet_rg_name"></a> [azure\_vnet\_rg\_name](#input\_azure\_vnet\_rg\_name) | Name of the Resource Group of the Azure VNet that is defined in the 'azure\_vnet\_name' variable. | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "azure_resource_lock" {
 }
 
 variable "azure_subscription_id" {
-  description = "Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources. DEPRECATED: This variable is no longer required as the subscription ID is now determined by the provider configuration."
+  description = "Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources. Deprecated: This variable is no longer required as the subscription ID is now determined by the provider configuration."
   type        = string
   default     = null
 
@@ -195,7 +195,7 @@ variable "timeout" {
   default     = "4m"
 }
 
-check "azure_subscription_id_deprecation" {
+check "depercations" {
   assert {
     condition     = var.azure_subscription_id == null
     error_message = "The 'azure_subscription_id' variable is deprecated and should not be used as it will be removed in a future release. Configure the subscription ID in the azurerm provider configuration instead."

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,14 @@ variable "azure_resource_lock" {
 }
 
 variable "azure_subscription_id" {
-  description = "Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources."
+  description = "Subscription ID of the Azure account to deploy Rubrik Cloud Cluster resources. DEPRECATED: This variable is no longer required as the subscription ID is now determined by the provider configuration."
   type        = string
+  default     = null
+
+  validation {
+    condition     = var.azure_subscription_id == null ? true : can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.azure_subscription_id))
+    error_message = "The subscription ID must be a valid UUID format if provided."
+  }
 }
 
 variable "azure_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -194,3 +194,10 @@ variable "timeout" {
   type        = string
   default     = "4m"
 }
+
+check "azure_subscription_id_deprecation" {
+  assert {
+    condition     = var.azure_subscription_id == null
+    error_message = "The 'azure_subscription_id' variable is deprecated and should not be used as it will be removed in a future release. Configure the subscription ID in the azurerm provider configuration instead."
+  }
+}


### PR DESCRIPTION
# Description

Since v1.0.0 we removed the requirements to provide an azure subscription ID for the module. This was due to the fact AzureRM requires this and it was previously hard-coded in the module.

## Motivation and Context

This is not a required attribute any further so it needs to be deprecated.

## How Has This Been Tested?

Testing will occur in beta.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
