### PR TITLE
Make the Storage service endpoint of the VPC optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,11 +74,11 @@ resource "azapi_resource" "cc_container" {
   }
 }
 
-# Note. this azapi_resource can be replaced with the "service_endpoints = ["Microsoft.Storage"]" 
+# Note. this azapi_resource can be replaced with the "service_endpoints = ["Microsoft.Storage"]"
 # option on the azurerm_subnet resource if the subnet is also created by Terraform.
 
 resource "azapi_update_resource" "cces_subnet_storage_endpoint" {
-
+  count       = var.azure_enable_subnet_storage_endpoint ? 1 : 0
   type        = "Microsoft.Network/virtualNetworks/subnets@2023-02-01"
   resource_id = data.azurerm_subnet.cces_subnet.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "azure_vnet_rg_name" {
 
 # Storage Variables
 
+variable "azure_enable_subnet_storage_endpoint" {
+  description = "Whether to enable the Storage service endpoint on the VPC subnet. Defaults to `true`."
+  type        = bool
+  default     = true
+}
+
 variable "azure_sa_name" {
   description = "The name of the Azure Storage Account to create for Rubrik Cloud Cluster resources."
   type        = string


### PR DESCRIPTION
# Description

The Storage endpoint is enabled by default, but it's possible to not enable it by setting azure_enable_subnet_storage_endpoint to false.

## Motivation and Context

Not enabling the Storage service endpoint reduces the permissions needed on the VPC.

## How Has This Been Tested?

The default behaviour is unchanged. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
