### PR TITLE
Add support for automatically registering the Cloud Cluster with RSC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -324,19 +324,31 @@ resource "time_sleep" "wait_for_nodes_to_boot" {
 }
 
 resource "polaris_cdm_bootstrap_cces_azure" "bootstrap_cces_azure" {
-  cluster_name            = var.cluster_name
-  cluster_nodes           = zipmap(local.cluster_node_names, local.cluster_node_ips)
-  admin_email             = var.admin_email
+  cluster_name           = var.cluster_name
+  cluster_nodes          = zipmap(local.cluster_node_names, local.cluster_node_ips)
+  admin_email            = var.admin_email
+  admin_password         = var.admin_password
+  management_gateway     = cidrhost(data.azurerm_subnet.cces_subnet.address_prefixes.0, 1)
+  management_subnet_mask = cidrnetmask(data.azurerm_subnet.cces_subnet.address_prefixes.0)
+  dns_search_domain      = var.dns_search_domain
+  dns_name_servers       = var.dns_name_servers
+  ntp_server1_name       = var.ntp_server1_name
+  ntp_server2_name       = var.ntp_server2_name
+  connection_string      = azurerm_storage_account.cc_storage_account.primary_connection_string
+  container_name         = var.cluster_name
+  enable_immutability    = var.enableImmutability
+  timeout                = var.timeout
+  depends_on             = [time_sleep.wait_for_nodes_to_boot]
+}
+
+##############################################
+# Register the Rubrik Cloud Cluster with RSC #
+##############################################
+
+resource "polaris_cdm_registration" "cces_azure_registration" {
+  count                   = var.register_cluster_with_rsc ? 1 : 0
   admin_password          = var.admin_password
-  management_gateway      = cidrhost(data.azurerm_subnet.cces_subnet.address_prefixes.0, 1)
-  management_subnet_mask  = cidrnetmask(data.azurerm_subnet.cces_subnet.address_prefixes.0)
-  dns_search_domain       = var.dns_search_domain
-  dns_name_servers        = var.dns_name_servers
-  ntp_server1_name        = var.ntp_server1_name
-  ntp_server2_name        = var.ntp_server2_name
-  connection_string       = azurerm_storage_account.cc_storage_account.primary_connection_string
-  container_name          = var.cluster_name
-  enable_immutability     = var.enableImmutability
-  timeout                 = var.timeout
-  depends_on              = [time_sleep.wait_for_nodes_to_boot]
+  cluster_name            = var.cluster_name
+  cluster_node_ip_address = local.cluster_node_ips[0]
+  depends_on              = [polaris_cdm_bootstrap_cces_azure.bootstrap_cces_azure]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,12 +6,12 @@ terraform {
       version = "~>4.14.0"
     }
     azapi = {
-      source = "Azure/azapi"
+      source  = "Azure/azapi"
       version = ">=2.0.0"
     }
     polaris = {
       source  = "rubrikinc/polaris"
-      version = "~>1.1.1"
+      version = "=>1.1.3"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,45 +156,59 @@ variable "ntp_server1_name" {
   type        = string
   default     = "8.8.8.8"
 }
+
 variable "ntp_server1_key_id" {
   description = "The ID number of the symmetric key used with NTP server #1. (Typically this is 0)"
   type        = number
   default     = 0
 }
+
 variable "ntp_server1_key" {
   description = "Symmetric key material for NTP server #1."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server1_key_type" {
   description = "Symmetric key type for NTP server #1."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server2_name" {
   description = "The FQDN or IPv4 addresses of network time protocol (NTP) server #2."
   type        = string
   default     = "8.8.4.4"
 }
+
 variable "ntp_server2_key_id" {
   description = "The ID number of the symmetric key used with NTP server #2. (Typically this is 0)"
   type        = number
   default     = 0
 }
+
 variable "ntp_server2_key" {
   description = "Symmetric key material for NTP server #2."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server2_key_type" {
   description = "Symmetric key type for NTP server #2."
   type        = string
   sensitive   = true
   default     = ""
 }
+
+variable "register_cluster_with_rsc" {
+  description = "Register the Rubrik Cloud Cluster with Rubrik Security Cloud."
+  type        = bool
+  default     = false
+}
+
 variable "timeout" {
   description = "The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error."
   type        = string


### PR DESCRIPTION
# Description

To register the cluster set the `register_cluster_with_rsc` module input variable to `true`. The default value of the module input variable is `false`.

The documentation and changelog will be updated in a separate PR.

## How Has This Been Tested?

Deployed a cloud cluster with the `register_cluster_with_rsc` module input variable set to `true`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
