### PR TITLE
Add support for using user assigned identities outside of this module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,6 @@
 * Relax the version constraint for the Azure RM Terraform provider to `>=4.14.0`.
 * Bump the RSC (polaris) Terraform provider from version `~>1.1.1` to `>=1.1.3`.
 * Run `terraform fmt` on the module.
-* 
-### v1.0.2
-* Make the Storage service endpoint of the VPC optional. The Storage endpoint is enabled by default, but it's possible
-  to not enable it by setting `azure_enable_subnet_storage_endpoint` module input variable to `false`.
-* Add support for automatically registering the Rubrik Cloud Cluster with Rubrik Security Cloud. To register the cluster
-  set the `register_cluster_with_rsc` module input variable to `true`.
-* NTP servers can now be specified using a FQDN. Previously they were required to be IP addresses, now both IP addresses
-  and FQDN are allowed.
-* Relax the version constraint for the Azure RM Terraform provider to `>=4.14.0`.
-* Bump the RSC (polaris) Terraform provider from version `~>1.1.1` to `>=1.1.3`.
-* Run `terraform fmt` on the module.
 
 ### v1.0.1
 * Deprecate the `azure_subscription_id` module input variable in favor of provider configuration provided by the root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+### v1.0.3
+* Ignore changes to identities attached to the VM outside of this module, allowing plans to run without removing them.
+
+### v1.0.2
+* Make the Storage service endpoint of the VPC optional. The Storage endpoint is enabled by default, but it's possible
+  to not enable it by setting `azure_enable_subnet_storage_endpoint` module input variable to `false`.
+* Add support for automatically registering the Rubrik Cloud Cluster with Rubrik Security Cloud. To register the cluster
+  set the `register_cluster_with_rsc` module input variable to `true`.
+* NTP servers can now be specified using a FQDN. Previously they were required to be IP addresses, now both IP addresses
+  and FQDN are allowed.
+* Relax the version constraint for the Azure RM Terraform provider to `>=4.14.0`.
+* Bump the RSC (polaris) Terraform provider from version `~>1.1.1` to `>=1.1.3`.
+* Run `terraform fmt` on the module.
+* 
 ### v1.0.2
 * Make the Storage service endpoint of the VPC optional. The Storage endpoint is enabled by default, but it's possible
   to not enable it by setting `azure_enable_subnet_storage_endpoint` module input variable to `false`.

--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,12 @@ resource "azurerm_linux_virtual_machine" "cces_node" {
     product   = "rubrik-data-protection"
   }
 
+  lifecycle {
+    ignore_changes = [
+      identity
+    ]
+  }
+
   tags = var.azure_tags
 
 }


### PR DESCRIPTION
# Description

In our environment, user assigned identities are managed outside of this module by Azure policy for enforcement of various policies. This results in a plan that tries to remove those policies on every apply. Since this module doesn't in itself require user assigned or managed identities, it seems safe to ignore changes to those blocks to support use cases like mine. 

## Related Issue

https://github.com/rubrikinc/terraform-azure-rubrik-cloud-cluster-elastic-storage/issues/17

## Motivation and Context

This allows the module to be used, and for a clean terraform plan to be constructed for changes without excess noise and risk.  

## How Has This Been Tested?

I ran this from my fork and as expected it showed no changes.

## Screenshots (if appropriate):

Before
<img width="1412" height="121" alt="Screenshot 2025-11-06 at 4 18 39 PM" src="https://github.com/user-attachments/assets/84842388-d1fb-43e8-95c0-c5d95269c443" />

After
<img width="988" height="54" alt="Screenshot 2025-11-06 at 4 18 30 PM" src="https://github.com/user-attachments/assets/6cb6a1d9-9927-4d74-b07b-ad9fac3b98fc" />

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
